### PR TITLE
Drop erronous info on hakyll metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ fit the pipes together however you like.
 ## Data/Metadata
 
 Metadata for posts and content is parsed from yaml into [Aeson's `Value`
-type](https://hackage.haskell.org/package/aeson); Unlike Hakyll which depends
-on Pandoc's metadata blocks which can only accept Strings as values, Aeson can
+type](https://hackage.haskell.org/package/aeson); Aeson can
 easily represent nested objects or lists inside your metadata, and there's a
 rich ecosystem for working with Aeson types! You can load resources in as any
 object which implements `FromJSON` (or just leave them as Aeson Values) and you


### PR DESCRIPTION
The statement on hakyll's metadata handling was not correct. Hakyll is not actually using pandoc's metadata (unfortunately), as pandoc uses a full YAML parser and supports nesting. Hakyll uses a custom metadata parser.  Judging from jaspvervdj/hakyll#225, the hakyll parser was updated to fully supports YAML, although I haven't tested that.