### PR TITLE
Relax upper bounds: megaparsec, Glob, lens, shelly

### DIFF
--- a/sitepipe.cabal
+++ b/sitepipe.cabal
@@ -28,7 +28,7 @@ library
                      , unordered-containers >= 0.2.8.0  && < 0.3
                      , directory            >= 1.3.0.0  && < 1.4
                      , filepath             >= 1.4.1.1  && < 1.5
-                     , megaparsec           >= 5.3.1    && < 6.3
+                     , megaparsec           >= 5.3.1    && < 6.6
                      , mtl                  >= 2.2.1    && < 2.3
                      , pandoc               >= 1.19.2   && < 1.20
                      , yaml                 >= 0.8.23.3 && < 0.9
@@ -37,11 +37,11 @@ library
                      , text                 >= 1.2.2.2  && < 1.3
                      , parsec               >= 3.1.11   && < 3.2
                      , exceptions           >= 0.8.3    && < 0.9
-                     , Glob                 >= 0.8.0    && < 0.9
+                     , Glob                 >= 0.8.0    && < 0.10
                      , lens-aeson           >= 1.0.2    && < 1.1
-                     , lens                 >= 4.15.4   && < 4.16
+                     , lens                 >= 4.15.4   && < 4.17
                      , aeson                >= 1.1.2.0  && < 1.3
-                     , shelly               >= 1.6.8    && < 1.7
+                     , shelly               >= 1.6.8    && < 1.8
                      , MissingH             >= 1.4.0.1  && < 1.5
                      , containers           >= 0.5.7.1  && < 0.6
 


### PR DESCRIPTION
Relax upper bounds on a few packages, so sitepipe will accept the versions currently in nixpgs.

See #18 , but the pandoc issues remain. I probably won't get to fixing them.